### PR TITLE
Fix for RSA Usage with Short Key

### DIFF
--- a/common/src/main/java/file/util/ImoocRSA.java
+++ b/common/src/main/java/file/util/ImoocRSA.java
@@ -67,7 +67,7 @@ public class ImoocRSA {
         getPubKey();
         getPriKey();
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-        keyPairGenerator.initialize(512);
+        keyPairGenerator.initialize(2048);
         KeyPair keyPair = keyPairGenerator.generateKeyPair();
         PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(rsaPrivateKey.getEncoded());
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");


### PR DESCRIPTION
[Issue Link](http://localhost/issues/eyJ0YWdfaWQiOiB7InJlcG9zaXRvcnlfaWQiOiB7InByb3ZpZGVyX2lkIjogIkdpdGh1YiIsICJwcm92aWRlcl9vd25lcl9pZCI6ICI1Mjc1NDAwMyIsICJwcm92aWRlcl9yZXBvc2l0b3J5X2lkIjogIk1ERXdPbEpsY0c5emFYUnZjbmt5TXpNd05qTTNOalk9In0sICJuYW1lIjogIm9yaWdpbi9tYXN0ZXIifSwgInJlcG9ydF9pZCI6IDE5NjJ9?issue_id=eyJyZXBvcnRfaWQiOiB7InRhZ19pZCI6IHsicmVwb3NpdG9yeV9pZCI6IHsicHJvdmlkZXJfaWQiOiAiR2l0aHViIiwgInByb3ZpZGVyX293bmVyX2lkIjogIjUyNzU0MDAzIiwgInByb3ZpZGVyX3JlcG9zaXRvcnlfaWQiOiAiTURFd09sSmxjRzl6YVhSdmNua3lNek13TmpNM05qWT0ifSwgIm5hbWUiOiAib3JpZ2luL21hc3RlciJ9LCAicmVwb3J0X2lkIjogMTk2Mn0sICJpc3N1ZV9pZCI6IDE5MDMyfQ%3D%3D)

Rivest-Shamir-Adleman (RSA) is an asymmetric public-key scheme, and for it to be effective in resisting attacks a factor is to set the key size to a suitable length protecting against brute-force attacks or integer factorization. NIST as of January 2015 published a paper for [Key Management](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf) outlining a recommended minimum size of 2048 bits, but this is also dependent up on the longevity of the information that is being protected.

RSA Key Pair Generation
```
KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
kpg.initialize(2048); // or higher
KeyPair kp = kpg.generateKeyPair();

// get the private and public keys
Key pub = kp.getPublic();
Key pvt = kp.getPrivate();

// save to file
String outFile = </path/to/file>;
out = new FileOutputStream(outFile + ".key");
out.write(pvt.getEncoded());
out.close();

out = new FileOutputStream(outFile + ".pub");
out.write(pvt.getEncoded());
out.close();
```